### PR TITLE
Removing call to `Cudd_RecursiveDeref`

### DIFF
--- a/src/inference/cudd/compile.jl
+++ b/src/inference/cudd/compile.jl
@@ -87,9 +87,9 @@ function compile_existing(c::BDDCompiler, root::AnyBool)::CuddNode
         for child in unique(children(node))
             c.num_uncompiled_parents[child] -= 1
             @assert c.num_uncompiled_parents[child] >= 0
-            if c.num_uncompiled_parents[child] == 0
-                Cudd_RecursiveDeref(c.mgr, c.cache[child])
-            end
+            # if c.num_uncompiled_parents[child] == 0
+            #     Cudd_RecursiveDeref(c.mgr, c.cache[child])
+            # end
         end
     end
     

--- a/test/inference/compile_test.jl
+++ b/test/inference/compile_test.jl
@@ -1,5 +1,6 @@
 using Test
 using Dice
+using Distributions
 
 @testset "BDDCompiler" begin
     f1 = flip(0.5)
@@ -19,4 +20,30 @@ end
     @test num_nodes(f1) == 3
     @test num_nodes(DistUInt{2}([f1, f2])) == 3
     @test num_nodes(uniform(DistUInt{3})) == 5
+end
+
+@testset "Cudd_RecursiveDeref GC issue" begin
+    x1s = -1.359
+    x2s = -0.458
+    error1 = -2.25
+    y1s = x1s + 2*x2s + error1
+    
+    X = hcat(x1s, x2s)
+    S = hcat([2, 0], [0, 2])
+    sigma = inv(transpose(X) * X + inv(S))
+    mu = sigma * transpose(transpose(y1s) * X)
+    
+    bits = 7
+    pieces = 2^(8)
+    DFiP = DistFix{9+bits, bits}
+    
+    w1 = bitblast(DFiP, Normal(0, sqrt(2)), pieces, -8.0, 8.0)
+    w2 = bitblast(DFiP, Normal(0, sqrt(2)), pieces, -8.0, 8.0)
+    code = @dice begin
+                error1 = bitblast(DFiP, Normal(0, 1), pieces, -8.0, 8.0)
+                observe(prob_equals(DFiP(y1s[1]), DFiP(x1s[1])*w1 + DFiP(x2s[1])*w2 + error1))
+                w1
+    end
+    
+    @test isapprox(expectation(code), mu[1]; atol = 0.1)
 end

--- a/test/inference/pr_test.jl
+++ b/test/inference/pr_test.jl
@@ -93,8 +93,8 @@ end
     @test debug_info_ref[].num_nodes == 196604
 
     pr(x, algo=Cudd(CUDD.CUDD_REORDER_SIFT, debug_info_ref))
-    @test debug_info_ref[].num_nodes == 160
+    @test debug_info_ref[].num_nodes == 1500
 
     pr(x, algo=Cudd(CUDD.CUDD_REORDER_WINDOW2, debug_info_ref))
-    @test debug_info_ref[].num_nodes == 129820
+    @test debug_info_ref[].num_nodes == 196860
 end


### PR DESCRIPTION
This PR comments out the call to `Cudd_RecursiveDeref` because currently dereferencing is not done properly. This led to accuracy issues and segmentation faults. Relevant tests have been added in `test/inference/compile_test.jl` and tests modified in `test/inference/pr_test.jl`